### PR TITLE
Update to april 2025 release.

### DIFF
--- a/site/src/DownloadCatalog.js
+++ b/site/src/DownloadCatalog.js
@@ -1,4 +1,4 @@
-import manifest from './manifests/03-19-25-manifest.json';
+import manifest from './manifests/2025-04-23.json';
 
 const awsbasepath = 'https://overturemaps-us-west-2.s3.amazonaws.com/release/';
 

--- a/site/src/Map.jsx
+++ b/site/src/Map.jsx
@@ -21,7 +21,7 @@ import ThemeTypeLayer from "./ThemeTypeLayer";
 import FeaturePopup from "./FeatureSelector";
 
 const PMTILES_URL =
-  "pmtiles://https://d3c1b7bog2u1nn.cloudfront.net/2025-03-19/";
+  "pmtiles://https://d3c1b7bog2u1nn.cloudfront.net/2025-04-23/";
 
 const INITIAL_VIEW_STATE = {
   latitude: 38.90678,


### PR DESCRIPTION
This PR contains the minimal set of changes that need to be done to the explore site to point to a new release's tiles and manifest. 

The tiles are for viz, the manifest powers the downloads. 